### PR TITLE
Make library more easily used by other

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,11 @@
         "syntax-flow",
         "syntax-async-functions",
         "transform-flow-strip-types",
-        "transform-async-to-generator"
+        "transform-async-to-generator",
+        ["transform-runtime", {
+          "polyfill": false,
+          "regenerator": true
+        }]
       ],
     },
     "production": {
@@ -16,7 +20,11 @@
         "syntax-async-functions",
         "transform-object-rest-spread",
         "transform-flow-strip-types",
-        "transform-async-to-generator"
+        "transform-async-to-generator",
+        ["transform-runtime", {
+          "polyfill": false,
+          "regenerator": true
+        }]
       ]
     }
   }

--- a/.babelrc
+++ b/.babelrc
@@ -7,10 +7,7 @@
         "syntax-async-functions",
         "transform-flow-strip-types",
         "transform-async-to-generator",
-        ["transform-runtime", {
-          "polyfill": false,
-          "regenerator": true
-        }]
+        "transform-runtime"
       ],
     },
     "production": {
@@ -21,10 +18,7 @@
         "transform-object-rest-spread",
         "transform-flow-strip-types",
         "transform-async-to-generator",
-        ["transform-runtime", {
-          "polyfill": false,
-          "regenerator": true
-        }]
+        "transform-runtime"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/mrjackdavis/roar-mongo#readme",
   "dependencies": {
-    "babel-polyfill": "^6.16.0",
+    "babel-runtime": "^6.26.0",
     "mongodb": "^2.2.11",
     "rxjs": "^5.0.0-rc.1"
   },
@@ -29,6 +29,7 @@
     "babel-plugin-syntax-flow": "^6.18.0",
     "babel-plugin-transform-async-to-generator": "^6.16.0",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-es2017": "^6.16.0",
     "babel-preset-es2017-node7": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "roar-mongo",
-  "version": "0.1.6",
+  "name": "@trioxis/roar-mongo",
+  "version": "0.3.0-alpha+1",
   "description": "Observable interface for MongoDB",
   "main": "dist/Repository.js",
   "scripts": {
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrjackdavis/roar-mongo.git"
+    "url": "git+https://github.com/Trioxis/roar-mongo.git"
   },
   "author": "Jack Davis",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrjackdavis/roar-mongo/issues"
+    "url": "https://github.com/Trioxis/roar-mongo/issues"
   },
-  "homepage": "https://github.com/mrjackdavis/roar-mongo#readme",
+  "homepage": "https://github.com/Trioxis/roar-mongo#readme",
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "mongodb": "^2.2.11",

--- a/src/MongoConnect.js
+++ b/src/MongoConnect.js
@@ -1,5 +1,4 @@
 // @flow
-import "babel-polyfill";
 import {MongoClient} from 'mongodb';
 
 import crypto from 'crypto';

--- a/src/Repository.js
+++ b/src/Repository.js
@@ -1,5 +1,4 @@
 // @flow
-import "babel-polyfill";
 import { Observable } from 'rxjs/Rx';
 
 type RepoIn<TIn,TOut> = (obj:TIn)=>TOut;

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,6 +485,12 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -492,7 +498,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.16.0, babel-polyfill@^6.26.0:
+babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:


### PR DESCRIPTION
From [babel-polyfill](https://babeljs.io/docs/usage/polyfill):
> This will emulate a full ES2015+ environment and is intended to be used **in an application rather than a library/tool**.

> If you are looking for something that won't modify globals to be used in a tool/library, checkout the transform-runtime plugin.

When I was using `roar-mongo` I was getting errors about `babel-polyfill` only being allowed once.

This change uses the [`transform-runtime`](https://babeljs.io/docs/plugins/transform-runtime) plugin instead of `babel-polyfill`